### PR TITLE
ログ周りの動作の正常化＆仕様上不要だった管理画面のログ動作の削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 〇ファイル構成(予定)
 sensei-switch/
 ├─ app/
+│  ├─ logs
+│  │  ├─ format_error.log
+│  │  ├─ unregistered_id.log
+│  │  └─status_change.log
 │  ├─ main.py
 │  ├─ handlers_status.py
 │  ├─ api_admin_logic.py
@@ -19,9 +23,10 @@ sensei-switch/
 │       └─ js/
 │          ├─ admin.js
 │          └─ view.js
-├─ .gignore
+├─ .gitignore
 ├─ Dockerfile
 ├─ docker-compose.yml
+├─ entrypoint.sh
 └─ README.md
 
 

--- a/app/api_admin_logic.py
+++ b/app/api_admin_logic.py
@@ -16,7 +16,6 @@ from typing import Dict, Any, List
 
 import db
 import logging
-from utils_log import log_info
 
 
 # ============================================================
@@ -51,11 +50,7 @@ def get_people_list() -> Dict[str, Any]:
         }
     """
     try:
-        log_info("管理者用 人物一覧取得を開始")
-
         people = db.get_people_all()
-
-        log_info(f"人物一覧取得成功: 件数={len(people)}")
 
         return {
             "result": "ok",
@@ -89,16 +84,7 @@ def apply_bulk_updates(records: List[Dict[str, Any]]) -> Dict[str, Any]:
         db.apply_bulk_updates の戻り値をそのまま返す
     """
     try:
-        log_info(f"人物一括更新開始: 件数={len(records)}")
-
         result = db.apply_bulk_updates(records)
-
-        log_info(
-            f"人物一括更新完了: "
-            f"updated={result.get('updated')}, "
-            f"inserted={result.get('inserted')}, "
-            f"errors={len(result.get('errors', []))}"
-        )
 
         return result
 
@@ -118,11 +104,7 @@ def insert_person(default_data: Dict[str, Any]) -> int:
     新規人物を people テーブルに追加する。
     """
     try:
-        log_info(f"人物追加開始: default_data={default_data}")
-
         new_id = db.insert_person(default_data)
-
-        log_info(f"人物追加成功: person_id={new_id}")
 
         return new_id
 
@@ -142,11 +124,7 @@ def delete_person(person_id: int) -> None:
     指定された人物を削除する。
     """
     try:
-        log_info(f"人物削除開始: person_id={person_id}")
-
         db.delete_person(person_id)
-
-        log_info(f"人物削除成功: person_id={person_id}")
 
     except Exception:
         logging.exception("人物削除失敗")

--- a/app/handlers_status.py
+++ b/app/handlers_status.py
@@ -20,6 +20,13 @@ import logging
 import re
 
 
+
+# ★ モジュールロード時に一度だけ保証
+try:
+    utils_log.ensure_log_dir_exists()
+except Exception:
+    logging.exception("log directory initialization failed")
+
 # ログファイル名（設計仕様書の規定に準拠）
 FORMAT_ERROR_LOG = "format_error.log"
 UNREGISTERED_ID_LOG = "unregistered_id.log"


### PR DESCRIPTION
１．動作の正常化
権限周りがややこしかったのでログの保存場所をプロジェクト直下に変更
併せて諸々パスとかファイル構成とか修正

２．管理画面のログ動作の削除
GPTくんが本来いらない（仕様書にもやんないって書いてた）管理画面のログ動作勝手に作ってたのが判明したので削除

○実装しているログ動作
・対応状況の変更ログ（変わったときのみ）
・フォーマットエラーログ（データ数が奇数だったり空文字だったり）
・未登録IDログ（DBにないor整数にできない）